### PR TITLE
v2 API migration: OAuth 2.0, media upload, 16 tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .env
 *.env
 .env.*
+.x-mcp-tokens.json
 
 # IDE specific files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -1,283 +1,190 @@
 # X MCP Server
 
-A Model Context Protocol (MCP) server for X (Twitter) integration that provides tools for reading your timeline and engaging with tweets. Designed for use with Claude desktop.
+A Model Context Protocol (MCP) server for X (Twitter) integration. Provides 16 tools for reading timelines, posting, searching, engagement (likes, retweets, bookmarks), and user lookup. Designed for use with Claude desktop and other MCP-compatible clients.
 
 <a href="https://glama.ai/mcp/servers/5nx3qqiunw"><img width="380" height="200" src="https://glama.ai/mcp/servers/5nx3qqiunw/badge" alt="X Server MCP server" /></a>
 
 ## Features
 
-- Get tweets from your home timeline
-- Create new tweets with optional image attachments
-- Reply to tweets with optional image attachments
-- Delete tweets
-- Image upload support (PNG, JPEG, GIF, WEBP)
-- Built-in security validation and file size limits
-- Built-in rate limit handling for the free API tier
-- TypeScript implementation with full type safety
+- **Timeline & Search** — Home timeline, search recent posts (7-day window)
+- **Post Management** — Create, reply, quote, delete posts with optional media
+- **Engagement** — Like/unlike, retweet/undo, bookmark/unbookmark
+- **User Lookup** — Get user profiles and their recent posts
+- **Media Upload** — Images (PNG, JPEG, GIF, WEBP) and videos (MP4, MOV, AVI, WEBM, M4V) via v2 upload API
+- **Dual Auth** — OAuth 1.0a for post operations, OAuth 2.0 for media upload (v1.1 upload was sunset June 2025)
+- **Rate Limiting** — Automatic per-endpoint rate limit tracking with clear error messages
+- **TypeScript** — Full type safety, modular file structure
 
 ## Prerequisites
 
-- Node.js (v16 or higher)
-- X (Twitter) Developer Account (Free)
-- Claude desktop app
+- Node.js >= 18.0.0
+- X (Twitter) Developer Account
+- Claude desktop app (or any MCP-compatible client)
 
-## X API Access
+## X API Access & Pricing
 
-X (Twitter) provides a free tier for basic API access:
+| Tier | Cost | Post Reads | Post Writes | Notes |
+|------|------|-----------|-------------|-------|
+| **Free** | $0 | ~100/month | ~500/month | No likes/follows; media upload requires OAuth 2.0 |
+| **Basic** | $200/month | 10,000/month | 3,000/month | Search, limited read access |
+| **Pro** | $5,000/month | 1,000,000/month | 300,000/month | Full search, filtered stream |
+| **Pay-Per-Use** | Credit-based | ~$0.005/read | Varies | Launched Feb 2026, 2M reads cap |
 
-### Free Tier Features
-- **Post Limits:** 
-  - 500 posts per month at user level
-  - 500 posts per month at app level
-- **Read Limits:**
-  - 100 reads per month
-- **Features:**
-  - Access to v2 post posting endpoints
-  - Media upload endpoints
-  - Access to Ads API
-  - Limited to 1 app ID
-  - Login with X functionality
-- **Rate Limits:**
-  - Rate-limited access to all endpoints
-  - Limits reset periodically
-
-Note: For higher volume needs, paid tiers are available:
-- Basic tier ($100/month): 50,000 tweets/month, additional endpoints
-- Pro tier ($5000/month): Higher limits and enterprise features
-
-You can access the free tier at: https://developer.x.com/en/portal/products/free
+> Like and Follow endpoints were removed from the Free tier in August 2025.
+> Follows/Blocks endpoints are Enterprise-only as of 2025.
 
 ## Installation
 
-1. Clone the repository:
 ```bash
-git clone [your-repo-url]
+git clone https://github.com/DataWhisker/x-mcp-server.git
 cd x-mcp-server
-```
-
-2. Install dependencies:
-```bash
 npm install
-```
-
-3. Build the server:
-```bash
 npm run build
 ```
 
-## Configuration
+## Authentication
 
-You need to set up your X (Twitter) API credentials. Follow these detailed steps:
+The server supports two authentication methods. You need **at least one** configured.
 
-1. Go to the [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard)
-   - Sign in with your X (Twitter) account
-   - If you don't have a developer account, you'll be prompted to create one
+### OAuth 1.0a (Required for basic operations)
 
-2. Access the Free Tier:
-   - Visit https://developer.x.com/en/portal/products/free
-   - Click "Subscribe" for the Free Access tier
-   - Complete the registration process
+Works for all post/engagement/search/user operations.
 
-3. Create a new project:
-   - Click "Create Project" button
-   - Enter a project name (e.g., "MCP Integration")
-   - Select "Free" as your setup
-   - Choose your use case
-   - Click "Next"
+| Environment Variable | Description |
+|---------------------|-------------|
+| `TWITTER_API_KEY` | Consumer Key (API Key) |
+| `TWITTER_API_SECRET` | Consumer Secret (API Key Secret) |
+| `TWITTER_ACCESS_TOKEN` | User Access Token |
+| `TWITTER_ACCESS_SECRET` | User Access Token Secret |
 
-4. Create a new app within your project:
-   - Click "Create App"
-   - Enter an app name
-   - Click "Complete Setup"
+**Setup:** In the [X Developer Portal](https://developer.x.com/en/portal/dashboard):
+1. Create a project and app
+2. Enable OAuth 1.0a under "User authentication settings"
+3. Set permissions to "Read and Write"
+4. Generate Consumer Keys and Access Tokens
 
-5. Configure app settings:
-   - In your app dashboard, click "App Settings"
-   - Under "User authentication settings":
-     - Click "Set Up"
-     - Enable OAuth 1.0a
-     - Select "Web App" or "Native App"
-     - Enter any URL for callback (e.g., https://example.com/callback)
-     - Enter any URL for website (e.g., https://example.com)
-     - Click "Save"
+### OAuth 2.0 (Required for media upload)
 
-6. Set app permissions:
-   - In app settings, find "App permissions"
-   - Change to "Read and Write"
-   - Click "Save"
+The v1.1 media upload endpoint was sunset in June 2025. Media upload now requires OAuth 2.0 via the v2 upload API.
 
-7. Generate API Keys and Tokens:
-   - Go to "Keys and Tokens" tab
-   - Under "Consumer Keys":
-     - Click "View Keys" or "Regenerate"
-     - Save your API Key and API Key Secret
-   - Under "Access Token and Secret":
-     - Click "Generate"
-     - Make sure to select tokens with "Read and Write" permissions
-     - Save your Access Token and Access Token Secret
+**Option A — Direct access token:**
 
-Important: 
-- Keep your keys and tokens secure and never share them publicly
-- You'll need all four values:
-  - API Key (also called Consumer Key)
-  - API Key Secret (also called Consumer Secret)
-  - Access Token
-  - Access Token Secret
-- Remember the free tier limits:
-  - 500 posts per month at user level
-  - 500 posts per month at app level
-  - 100 reads per month
+| Variable | Description |
+|----------|-------------|
+| `TWITTER_OAUTH2_ACCESS_TOKEN` | OAuth 2.0 user access token (expires in 2 hours) |
+
+**Option B — Auto-refresh (recommended for long-running servers):**
+
+| Variable | Description |
+|----------|-------------|
+| `TWITTER_CLIENT_ID` | OAuth 2.0 Client ID |
+| `TWITTER_CLIENT_SECRET` | OAuth 2.0 Client Secret (optional for public clients) |
+| `TWITTER_OAUTH2_REFRESH_TOKEN` | OAuth 2.0 Refresh Token |
+
+Tokens are auto-refreshed and persisted to `~/.x-mcp-tokens.json`.
+
+**Setup:** In the [X Developer Portal](https://developer.x.com/en/portal/dashboard):
+1. In your app settings, enable OAuth 2.0
+2. Set type to "Confidential client" or "Public client"
+3. Add a callback URL
+4. Request scopes: `tweet.read`, `tweet.write`, `users.read`, `media.write`, `offline.access`, `like.read`, `like.write`, `bookmark.read`, `bookmark.write`
 
 ## Claude Desktop Configuration
 
-To connect the X MCP server with Claude desktop, you need to configure it in the Claude settings. Follow these steps:
+Add to `%APPDATA%/Claude/claude_desktop_config.json`:
 
-1. Open File Explorer
-2. Navigate to the Claude config directory:
-   - Press Win + R
-   - Type `%APPDATA%/Claude` and press Enter
-   - If the Claude folder doesn't exist, create it
-
-3. Create or edit `claude_desktop_config.json`:
-   - If the file doesn't exist, create a new file named `claude_desktop_config.json`
-   - If it exists, open it in a text editor (like Notepad)
-
-4. Add the following configuration, replacing the placeholder values with your actual API credentials from the previous section:
 ```json
 {
   "mcpServers": {
     "x": {
       "command": "node",
-      "args": ["%USERPROFILE%/Projects/MCP Basket/x-server/build/index.js"],
+      "args": ["C:/path/to/x-mcp-server/build/index.js"],
       "env": {
-        "TWITTER_API_KEY": "paste-your-api-key-here",
-        "TWITTER_API_SECRET": "paste-your-api-key-secret-here",
-        "TWITTER_ACCESS_TOKEN": "paste-your-access-token-here",
-        "TWITTER_ACCESS_SECRET": "paste-your-access-token-secret-here"
+        "TWITTER_API_KEY": "your-api-key",
+        "TWITTER_API_SECRET": "your-api-secret",
+        "TWITTER_ACCESS_TOKEN": "your-access-token",
+        "TWITTER_ACCESS_SECRET": "your-access-secret",
+        "TWITTER_OAUTH2_ACCESS_TOKEN": "your-oauth2-token"
       }
     }
   }
 }
 ```
 
-5. Save the file and restart Claude desktop
+## Available Tools (16)
 
-Note: Make sure to:
-- Replace all four credential values with your actual API keys and tokens
-- Keep the quotes ("") around each value
-- Maintain the exact spacing and formatting shown above
-- Save the file with the `.json` extension
+### Timeline & Search
 
-## Available Tools
+| Tool | Description | Key Parameters |
+|------|-------------|---------------|
+| `get_home_timeline` | Get recent posts from home timeline | `limit` (1-100) |
+| `search_tweets` | Search recent posts (7-day window) | `query`, `limit` |
 
-### get_home_timeline
-Get the most recent tweets from your home timeline.
+### Post Management
 
-Parameters:
-- `limit` (optional): Number of tweets to retrieve (default: 20, max: 100)
+| Tool | Description | Key Parameters |
+|------|-------------|---------------|
+| `get_tweet` | Look up a post by ID | `tweet_id` |
+| `create_tweet` | Create a post with optional media | `text`, `image_path?`, `video_path?` |
+| `reply_to_tweet` | Reply to a post with optional media | `tweet_id`, `text`, `image_path?`, `video_path?` |
+| `quote_tweet` | Quote a post with commentary | `tweet_id`, `text` |
+| `delete_tweet` | Delete your post | `tweet_id` |
 
-Example:
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "get_home_timeline",
-  arguments: { limit: 5 }
-});
-```
+### Engagement
 
-### create_tweet
-Create a new tweet with optional image attachment.
+| Tool | Description | Key Parameters |
+|------|-------------|---------------|
+| `like_tweet` | Like a post (Basic+ tier) | `tweet_id` |
+| `unlike_tweet` | Remove a like | `tweet_id` |
+| `retweet` | Repost to your timeline | `tweet_id` |
+| `undo_retweet` | Remove a repost | `tweet_id` |
+| `bookmark_tweet` | Bookmark for later | `tweet_id` |
+| `unbookmark_tweet` | Remove a bookmark | `tweet_id` |
+| `get_bookmarks` | Get your bookmarks | `limit` (1-100) |
 
-Parameters:
-- `text` (required): The text content of the tweet (max 280 characters)
-- `image_path` (optional): Absolute path to an image file (PNG, JPEG, GIF, WEBP, max 5MB)
+### Users
 
-Example (text-only):
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "create_tweet",
-  arguments: { text: "Hello from MCP! 🤖" }
-});
-```
+| Tool | Description | Key Parameters |
+|------|-------------|---------------|
+| `get_user` | Look up user by username | `username` |
+| `get_user_tweets` | Get a user's recent posts | `username`, `limit` |
 
-Example (with image):
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "create_tweet",
-  arguments: {
-    text: "Check out this image! 📸",
-    image_path: "/path/to/image.png"
-  }
-});
-```
+## Media Support
 
-### reply_to_tweet
-Reply to a tweet with optional image attachment.
+- **Images:** PNG, JPEG, GIF, WEBP (max 5MB)
+- **Videos:** MP4, MOV, AVI, WEBM, M4V (max 512MB, streamed chunked upload)
+- Cannot attach both image and video to the same post
+- Requires OAuth 2.0 credentials (v1.1 upload sunset June 2025)
+- **Path restriction:** Only files within your home directory or system temp directory can be uploaded (prevents path traversal)
 
-Parameters:
-- `tweet_id` (required): The ID of the tweet to reply to
-- `text` (required): The text content of the reply (max 280 characters)
-- `image_path` (optional): Absolute path to an image file (PNG, JPEG, GIF, WEBP, max 5MB)
+## Security
 
-Example (text-only):
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "reply_to_tweet",
-  arguments: {
-    tweet_id: "1234567890",
-    text: "Great tweet! 👍"
-  }
-});
-```
-
-Example (with image):
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "reply_to_tweet",
-  arguments: {
-    tweet_id: "1234567890",
-    text: "Here's my response 📸",
-    image_path: "/path/to/image.jpg"
-  }
-});
-```
-
-### delete_tweet
-Delete a tweet.
-Parameters:
-- `tweet_id` (required): The ID of the tweet to delete
-Example:
-```typescript
-await use_mcp_tool({
-  server_name: "x",
-  tool_name: "delete_tweet",
-  arguments: {
-    tweet_id: "1234567890"
-  }
-});
-```
+- **Input validation:** Tweet IDs must be numeric (1-20 digits), usernames must match `[A-Za-z0-9_]{1,15}`
+- **Media path restriction:** Upload paths are validated against an allow-list (home directory, temp directory)
+- **Token storage:** OAuth 2.0 tokens persisted to `~/.x-mcp-tokens.json` with `0o600` permissions (Unix). On Windows, file permissions are not enforced by the OS — protect the file via NTFS ACLs or use environment variables instead.
+- **Error sanitization:** X API error details are logged server-side only; sanitized messages are returned to MCP clients
+- **Refresh mutex:** Concurrent token refresh attempts are deduplicated to prevent race conditions
 
 ## Development
 
-- `npm run build`: Build the TypeScript code
-- `npm run dev`: Run TypeScript in watch mode
-- `npm start`: Start the MCP server
+```bash
+npm run build    # Compile TypeScript
+npm run dev      # Watch mode
+npm start        # Run the server
+```
 
-## Rate Limiting
+## Project Structure
 
-The server includes built-in rate limit handling for X's free tier:
-- Monthly limits:
-  - 500 posts per month at user level
-  - 500 posts per month at app level
-  - 100 reads per month
-- Features:
-  - Tracks monthly usage
-  - Provides exponential backoff for rate limit errors
-  - Clear error messages when limits are reached
-  - Automatic retry after rate limit window expires
+```
+src/
+  index.ts              # MCP server entry point & handler dispatch
+  client.ts             # Twitter client setup (OAuth 1.0a + OAuth 2.0)
+  media.ts              # v2 media upload (simple + chunked)
+  rate-limit.ts         # Per-endpoint rate limiting
+  tools/
+    definitions.ts      # All 16 tool schemas
+    handlers.ts         # Tool handler implementations
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,29 @@
 {
   "name": "x-mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "main": "build/index.js",
   "bin": {
     "x-mcp-server": "./build/index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
     "dev": "tsc -w"
   },
-  "keywords": ["mcp", "twitter", "x"],
+  "keywords": ["mcp", "twitter", "x", "api-v2"],
   "author": "",
-  "license": "ISC",
-  "description": "MCP server for X (Twitter) integration",
+  "license": "MIT",
+  "description": "MCP server for X (Twitter) integration — v2 API with OAuth 2.0 media upload",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "twitter-api-v2": "^1.15.0"
+  },
+  "devDependencies": {
     "@types/node": "^20.0.0",
-    "twitter-api-v2": "^1.15.0",
     "typescript": "^5.0.0"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,172 @@
+import { TwitterApi } from 'twitter-api-v2';
+import { readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const TOKEN_FILE = join(homedir(), '.x-mcp-tokens.json');
+const TOKEN_EXPIRY_BUFFER_MS = 60_000; // Refresh 1 minute before actual expiry
+
+interface StoredTokens {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresAt: number;
+}
+
+let cachedUserId: string | null = null;
+let oauth2Token: string | null = null;
+let oauth2RefreshToken: string | null = null;
+let oauth2ExpiresAt = 0;
+let refreshInProgress: Promise<string> | null = null;
+
+// Warn on Windows where file mode 0o600 is silently ignored
+if (process.platform === 'win32') {
+  console.error(
+    '[Security] Running on Windows — token file permissions (mode 0o600) are not enforced. ' +
+    'Ensure ~/.x-mcp-tokens.json is protected via NTFS ACLs or use environment variables instead.'
+  );
+}
+
+function createOAuth1Client(): TwitterApi | null {
+  const appKey = process.env.TWITTER_API_KEY;
+  const appSecret = process.env.TWITTER_API_SECRET;
+  const accessToken = process.env.TWITTER_ACCESS_TOKEN;
+  const accessSecret = process.env.TWITTER_ACCESS_SECRET;
+
+  if (!appKey || !appSecret || !accessToken || !accessSecret) {
+    return null;
+  }
+
+  return new TwitterApi({ appKey, appSecret, accessToken, accessSecret });
+}
+
+async function loadStoredTokens(): Promise<StoredTokens | null> {
+  try {
+    const data = await readFile(TOKEN_FILE, 'utf-8');
+    return JSON.parse(data) as StoredTokens;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error('[OAuth2] Token file read error:', (error as Error).message);
+    }
+    return null;
+  }
+}
+
+async function saveStoredTokens(tokens: StoredTokens): Promise<void> {
+  await writeFile(TOKEN_FILE, JSON.stringify(tokens, null, 2), { encoding: 'utf-8', mode: 0o600 });
+}
+
+async function refreshOAuth2TokenFromSource(): Promise<string> {
+  const clientId = process.env.TWITTER_CLIENT_ID;
+  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+  const refreshToken = oauth2RefreshToken ?? process.env.TWITTER_OAUTH2_REFRESH_TOKEN;
+
+  if (!clientId || !refreshToken) {
+    throw new Error(
+      'OAuth 2.0 client ID and refresh token required for token refresh'
+    );
+  }
+
+  // twitter-api-v2 types don't expose { clientId, clientSecret } as a constructor overload,
+  // but the library accepts it at runtime for OAuth2 refresh flows (tested with v1.15+).
+  // See: https://github.com/PLhery/node-twitter-api-v2/blob/master/doc/auth.md
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const authClient = clientSecret
+    ? new TwitterApi({ clientId, clientSecret } as any)
+    : new TwitterApi({ clientId } as any);
+
+  const result = await authClient.refreshOAuth2Token(refreshToken);
+
+  oauth2Token = result.accessToken;
+  oauth2RefreshToken = result.refreshToken ?? null;
+  oauth2ExpiresAt = Date.now() + result.expiresIn * 1000 - TOKEN_EXPIRY_BUFFER_MS;
+
+  await saveStoredTokens({
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken ?? refreshToken,
+    expiresAt: oauth2ExpiresAt,
+  });
+
+  return result.accessToken;
+}
+
+export async function getOAuth2Token(): Promise<string | null> {
+  if (process.env.TWITTER_OAUTH2_ACCESS_TOKEN) {
+    return process.env.TWITTER_OAUTH2_ACCESS_TOKEN;
+  }
+
+  if (oauth2Token && Date.now() < oauth2ExpiresAt) {
+    return oauth2Token;
+  }
+
+  const stored = await loadStoredTokens();
+  if (stored && Date.now() < stored.expiresAt) {
+    oauth2Token = stored.accessToken;
+    oauth2RefreshToken = stored.refreshToken;
+    oauth2ExpiresAt = stored.expiresAt;
+    return stored.accessToken;
+  }
+
+  if (stored?.refreshToken) {
+    oauth2RefreshToken = stored.refreshToken;
+  }
+
+  const clientId = process.env.TWITTER_CLIENT_ID ?? null;
+  const refreshAvailable = oauth2RefreshToken ?? process.env.TWITTER_OAUTH2_REFRESH_TOKEN ?? null;
+
+  if (clientId && refreshAvailable) {
+    // Prevent concurrent refresh attempts from racing
+    if (refreshInProgress) {
+      try {
+        return await refreshInProgress;
+      } catch {
+        return null;
+      }
+    }
+    try {
+      refreshInProgress = refreshOAuth2TokenFromSource();
+      return await refreshInProgress;
+    } catch (error) {
+      console.error('[OAuth2 Refresh] Token refresh failed:', (error as Error).message);
+      return null;
+    } finally {
+      refreshInProgress = null;
+    }
+  }
+
+  return null;
+}
+
+export async function getClient(): Promise<TwitterApi> {
+  const token = await getOAuth2Token();
+  if (token) {
+    return new TwitterApi(token);
+  }
+
+  const oauth1 = createOAuth1Client();
+  if (oauth1) {
+    return oauth1;
+  }
+
+  throw new Error(
+    'No Twitter credentials configured. ' +
+    'Set OAuth 1.0a vars (TWITTER_API_KEY, TWITTER_API_SECRET, TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_SECRET) ' +
+    'or OAuth 2.0 vars (TWITTER_OAUTH2_ACCESS_TOKEN or TWITTER_CLIENT_ID + TWITTER_OAUTH2_REFRESH_TOKEN).'
+  );
+}
+
+export async function getAuthenticatedUserId(): Promise<string> {
+  if (cachedUserId) return cachedUserId;
+
+  const client = await getClient();
+  const me = await client.v2.me();
+  cachedUserId = me.data.id;
+  return cachedUserId;
+}
+
+export function hasOAuth2Config(): boolean {
+  return !!(
+    process.env.TWITTER_OAUTH2_ACCESS_TOKEN ||
+    (process.env.TWITTER_CLIENT_ID && process.env.TWITTER_OAUTH2_REFRESH_TOKEN)
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,177 +6,60 @@ import {
   ErrorCode,
   ListToolsRequestSchema,
   McpError,
-  Tool,
-  TextContent
 } from '@modelcontextprotocol/sdk/types.js';
-import { TwitterApi } from 'twitter-api-v2';
-import { readFile, stat } from 'fs/promises';
-import { resolve, basename } from 'path';
+import { TOOL_DEFINITIONS } from './tools/definitions.js';
+import {
+  handleGetHomeTimeline,
+  handleSearchTweets,
+  handleGetTweet,
+  handleCreateTweet,
+  handleReplyToTweet,
+  handleQuoteTweet,
+  handleDeleteTweet,
+  handleLikeTweet,
+  handleUnlikeTweet,
+  handleRetweet,
+  handleUndoRetweet,
+  handleBookmarkTweet,
+  handleUnbookmarkTweet,
+  handleGetBookmarks,
+  handleGetUser,
+  handleGetUserTweets,
+} from './tools/handlers.js';
 
-// Helper function to upload media with validation
-async function uploadImage(client: TwitterApi, imagePath: string): Promise<string> {
-  // Sanitize path to prevent directory traversal
-  const sanitizedPath = resolve(imagePath);
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
+}>;
 
-  // Validate file exists and get stats
-  let fileStats;
-  try {
-    fileStats = await stat(sanitizedPath);
-  } catch (error) {
-    throw new Error(`File not found: ${basename(sanitizedPath)}`);
-  }
-
-  // Check if it's a file (not a directory)
-  if (!fileStats.isFile()) {
-    throw new Error(`Path is not a file: ${basename(sanitizedPath)}`);
-  }
-
-  // Twitter image size limit is 5MB
-  const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
-  if (fileStats.size > MAX_SIZE) {
-    throw new Error(`File size exceeds 5MB limit (${(fileStats.size / 1024 / 1024).toFixed(2)}MB)`);
-  }
-
-  // Detect mime type from file extension
-  const ext = sanitizedPath.toLowerCase().split('.').pop();
-  const mimeTypes: { [key: string]: string } = {
-    'png': 'image/png',
-    'jpg': 'image/jpeg',
-    'jpeg': 'image/jpeg',
-    'gif': 'image/gif',
-    'webp': 'image/webp'
-  };
-
-  // Validate supported format
-  if (!ext || !mimeTypes[ext]) {
-    const supported = Object.keys(mimeTypes).join(', ');
-    throw new Error(`Unsupported file format. Supported formats: ${supported}`);
-  }
-
-  const mimeType = mimeTypes[ext];
-
-  // Read and upload file
-  const imageBuffer = await readFile(sanitizedPath);
-  return await client.v1.uploadMedia(imageBuffer, { mimeType });
-}
-
-// Helper function to upload video with chunked upload
-async function uploadVideo(client: TwitterApi, videoPath: string): Promise<string> {
-  // Sanitize path to prevent directory traversal
-  const sanitizedPath = resolve(videoPath);
-
-  // Validate file exists and get stats
-  let fileStats;
-  try {
-    fileStats = await stat(sanitizedPath);
-  } catch (error) {
-    throw new Error(`File not found: ${basename(sanitizedPath)}`);
-  }
-
-  // Check if it's a file (not a directory)
-  if (!fileStats.isFile()) {
-    throw new Error(`Path is not a file: ${basename(sanitizedPath)}`);
-  }
-
-  // Twitter video size limit is 512MB
-  const MAX_SIZE = 512 * 1024 * 1024; // 512MB in bytes
-  if (fileStats.size > MAX_SIZE) {
-    throw new Error(`Video size exceeds 512MB limit (${(fileStats.size / 1024 / 1024).toFixed(2)}MB)`);
-  }
-
-  // Detect mime type from file extension
-  const ext = sanitizedPath.toLowerCase().split('.').pop();
-  const mimeTypes: { [key: string]: string } = {
-    'mp4': 'video/mp4',
-    'mov': 'video/quicktime',
-    'avi': 'video/x-msvideo',
-    'webm': 'video/webm',
-    'm4v': 'video/x-m4v'
-  };
-
-  // Validate supported format
-  if (!ext || !mimeTypes[ext]) {
-    const supported = Object.keys(mimeTypes).join(', ');
-    throw new Error(`Unsupported video format. Supported formats: ${supported}`);
-  }
-
-  const mimeType = mimeTypes[ext];
-
-  // Read video file
-  const videoBuffer = await readFile(sanitizedPath);
-
-  // Upload video using chunked upload
-  return await client.v1.uploadMedia(videoBuffer, {
-    mimeType,
-    target: 'tweet',
-    additionalOwners: undefined,
-    longVideo: fileStats.size > 15 * 1024 * 1024 // Use long video for files > 15MB
-  });
-}
-
-// Track rate limit reset times
-const rateLimitResets: { [key: string]: number } = {
-  'home': 0,
-  'tweet': 0,
-  'reply': 0,
-  'delete': 0
+const HANDLERS: Readonly<Record<string, ToolHandler>> = {
+  get_home_timeline: handleGetHomeTimeline,
+  search_tweets: handleSearchTweets,
+  get_tweet: handleGetTweet,
+  create_tweet: handleCreateTweet,
+  reply_to_tweet: handleReplyToTweet,
+  quote_tweet: handleQuoteTweet,
+  delete_tweet: handleDeleteTweet,
+  like_tweet: handleLikeTweet,
+  unlike_tweet: handleUnlikeTweet,
+  retweet: handleRetweet,
+  undo_retweet: handleUndoRetweet,
+  bookmark_tweet: handleBookmarkTweet,
+  unbookmark_tweet: handleUnbookmarkTweet,
+  get_bookmarks: handleGetBookmarks,
+  get_user: handleGetUser,
+  get_user_tweets: handleGetUserTweets,
 };
-
-// Helper function for rate limit handling
-async function withRateLimit<T>(endpoint: 'home' | 'tweet' | 'reply' | 'delete', fn: () => Promise<T>): Promise<T> {
-  const now = Date.now();
-  const resetTime = rateLimitResets[endpoint];
-  
-  if (now < resetTime) {
-    const waitTime = resetTime - now + 1000; // Add 1 second buffer
-    await new Promise(resolve => setTimeout(resolve, waitTime));
-  }
-
-  try {
-    const result = await fn();
-    // Set next reset time to 15 minutes from now for free tier
-    rateLimitResets[endpoint] = now + (15 * 60 * 1000);
-    return result;
-  } catch (error: any) {
-    if (error?.code === 429) {
-      // If we get a rate limit error, wait 15 minutes before next attempt
-      rateLimitResets[endpoint] = now + (15 * 60 * 1000);
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `Rate limit exceeded for ${endpoint}. Please try again in 15 minutes.`
-      );
-    }
-    throw error;
-  }
-}
-
-// Twitter API client setup
-const client = new TwitterApi({
-  appKey: process.env.TWITTER_API_KEY ?? '',
-  appSecret: process.env.TWITTER_API_SECRET ?? '',
-  accessToken: process.env.TWITTER_ACCESS_TOKEN ?? '',
-  accessSecret: process.env.TWITTER_ACCESS_SECRET ?? '',
-});
 
 class XMcpServer {
   private server: Server;
 
   constructor() {
     this.server = new Server(
-      {
-        name: 'x-mcp-server',
-        version: '1.0.0',
-      },
-      {
-        capabilities: {
-          tools: {},
-        },
-      }
+      { name: 'x-mcp-server', version: '2.0.0' },
+      { capabilities: { tools: {} } }
     );
 
     this.setupToolHandlers();
-    
-    // Error handling
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
       await this.server.close();
@@ -186,254 +69,24 @@ class XMcpServer {
 
   private setupToolHandlers() {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: 'get_home_timeline',
-          description: 'Get the most recent tweets from your home timeline',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              limit: {
-                type: 'number',
-                description: 'Number of tweets to retrieve (max 100)',
-                minimum: 1,
-                maximum: 100,
-                default: 20,
-              },
-            },
-          },
-        },
-        {
-          name: 'create_tweet',
-          description: 'Create a new tweet with optional image or video attachment',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              text: {
-                type: 'string',
-                description: 'The text content of the tweet',
-                maxLength: 280,
-              },
-              image_path: {
-                type: 'string',
-                description: 'Optional absolute path to an image file to attach (PNG, JPEG, GIF, WEBP)',
-              },
-              video_path: {
-                type: 'string',
-                description: 'Optional absolute path to a video file to attach (MP4, MOV, AVI, WEBM, M4V). Max 512MB. Cannot be used with image_path.',
-              },
-            },
-            required: ['text'],
-          },
-        },
-        {
-          name: 'reply_to_tweet',
-          description: 'Reply to a tweet with optional image or video attachment',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              tweet_id: {
-                type: 'string',
-                description: 'The ID of the tweet to reply to',
-              },
-              text: {
-                type: 'string',
-                description: 'The text content of the reply',
-                maxLength: 280,
-              },
-              image_path: {
-                type: 'string',
-                description: 'Optional absolute path to an image file to attach (PNG, JPEG, GIF, WEBP)',
-              },
-              video_path: {
-                type: 'string',
-                description: 'Optional absolute path to a video file to attach (MP4, MOV, AVI, WEBM, M4V). Max 512MB. Cannot be used with image_path.',
-              },
-            },
-            required: ['tweet_id', 'text'],
-          },
-        },
-        {
-          name: 'delete_tweet',
-          description: 'Delete one of your tweets',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              tweet_id: {
-                type: 'string',
-                description: 'The ID of the tweet to delete',
-              },
-            },
-            required: ['tweet_id'],
-          },
-        },
-      ],
+      tools: TOOL_DEFINITIONS,
     }));
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const handler = HANDLERS[name];
+
+      if (!handler) {
+        throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+      }
+
       try {
-        switch (request.params.name) {
-          case 'get_home_timeline': {
-            const { limit = 20 } = request.params.arguments as { limit?: number };
-            
-            const timeline = await withRateLimit('home', () => client.v2.homeTimeline({
-              max_results: Math.min(limit, 5), // Limit to max 5 tweets for free tier
-              'tweet.fields': ['author_id', 'created_at', 'referenced_tweets'],
-              expansions: ['author_id', 'referenced_tweets.id'],
-            }));
-            
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(timeline.data, null, 2),
-                },
-              ],
-            };
-          }
-
-          case 'create_tweet': {
-            const { text, image_path, video_path } = request.params.arguments as {
-              text: string;
-              image_path?: string;
-              video_path?: string;
-            };
-
-            // Validate that both image and video aren't provided
-            if (image_path && video_path) {
-              throw new McpError(
-                ErrorCode.InvalidRequest,
-                'Cannot attach both image and video to the same tweet. Please provide only one.'
-              );
-            }
-
-            let mediaId: string | undefined;
-
-            // Upload media if image_path is provided
-            if (image_path) {
-              try {
-                mediaId = await uploadImage(client, image_path);
-              } catch (error) {
-                throw new McpError(
-                  ErrorCode.InvalidRequest,
-                  `Failed to upload image: ${(error as Error).message}`
-                );
-              }
-            }
-
-            // Upload video if video_path is provided
-            if (video_path) {
-              try {
-                mediaId = await uploadVideo(client, video_path);
-              } catch (error) {
-                throw new McpError(
-                  ErrorCode.InvalidRequest,
-                  `Failed to upload video: ${(error as Error).message}`
-                );
-              }
-            }
-
-            const tweet = await withRateLimit('tweet', () =>
-              mediaId
-                ? client.v2.tweet({ text, media: { media_ids: [mediaId] } })
-                : client.v2.tweet(text)
-            );
-
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(tweet.data, null, 2),
-                },
-              ],
-            };
-          }
-
-          case 'reply_to_tweet': {
-            const { tweet_id, text, image_path, video_path } = request.params.arguments as {
-              tweet_id: string;
-              text: string;
-              image_path?: string;
-              video_path?: string;
-            };
-
-            // Validate that both image and video aren't provided
-            if (image_path && video_path) {
-              throw new McpError(
-                ErrorCode.InvalidRequest,
-                'Cannot attach both image and video to the same reply. Please provide only one.'
-              );
-            }
-
-            let mediaId: string | undefined;
-
-            // Upload media if image_path is provided
-            if (image_path) {
-              try {
-                mediaId = await uploadImage(client, image_path);
-              } catch (error) {
-                throw new McpError(
-                  ErrorCode.InvalidRequest,
-                  `Failed to upload image: ${(error as Error).message}`
-                );
-              }
-            }
-
-            // Upload video if video_path is provided
-            if (video_path) {
-              try {
-                mediaId = await uploadVideo(client, video_path);
-              } catch (error) {
-                throw new McpError(
-                  ErrorCode.InvalidRequest,
-                  `Failed to upload video: ${(error as Error).message}`
-                );
-              }
-            }
-
-            const reply = await withRateLimit('reply', () =>
-              mediaId
-                ? client.v2.tweet({ text, reply: { in_reply_to_tweet_id: tweet_id }, media: { media_ids: [mediaId] } })
-                : client.v2.reply(text, tweet_id)
-            );
-
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(reply.data, null, 2),
-                },
-              ],
-            };
-          }
-
-          case 'delete_tweet': {
-            const { tweet_id } = request.params.arguments as { tweet_id: string };
-            const deleted = await withRateLimit('delete', () => client.v2.deleteTweet(tweet_id));
-            
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(deleted.data, null, 2),
-                },
-              ],
-            };
-          }
-
-          default:
-            throw new McpError(
-              ErrorCode.MethodNotFound,
-              `Unknown tool: ${request.params.name}`
-            );
-        }
+        return await handler((args ?? {}) as Record<string, unknown>);
       } catch (error) {
-        if (error instanceof McpError) {
-          throw error;
-        }
+        if (error instanceof McpError) throw error;
         throw new McpError(
           ErrorCode.InternalError,
-          `Twitter API error: ${(error as Error).message}`
+          `X API error: ${(error as Error).message}`
         );
       }
     });
@@ -442,7 +95,7 @@ class XMcpServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error('X MCP server running on stdio');
+    console.error('X MCP server v2.0.0 running on stdio');
   }
 }
 

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,0 +1,271 @@
+import { open, stat } from 'fs/promises';
+import { resolve, basename, sep } from 'path';
+import { homedir, tmpdir } from 'os';
+import { getOAuth2Token, hasOAuth2Config } from './client.js';
+
+// X API v2 media upload endpoint (replaced v1.1 upload.twitter.com, sunset June 2025)
+// Ref: https://docs.x.com/x-api/media-upload/api-reference
+const UPLOAD_URL = 'https://upload.x.com/2/media/upload';
+const CHUNK_SIZE = 5 * 1024 * 1024;
+
+// Directories from which media upload is permitted (prevents path traversal)
+const ALLOWED_ROOTS = [
+  resolve(homedir()),
+  resolve(tmpdir()),
+];
+
+function assertSafePath(resolvedPath: string): void {
+  const isAllowed = ALLOWED_ROOTS.some(
+    (root) => resolvedPath.startsWith(root + sep) || resolvedPath === root
+  );
+  if (!isAllowed) {
+    throw new Error(
+      `File path is outside permitted directories. ` +
+      `Allowed roots: ${ALLOWED_ROOTS.join(', ')}`
+    );
+  }
+}
+
+const IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+const VIDEO_MIME_TYPES: Readonly<Record<string, string>> = {
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  webm: 'video/webm',
+  m4v: 'video/x-m4v',
+};
+
+const ALL_MIME_TYPES: Readonly<Record<string, string>> = {
+  ...IMAGE_MIME_TYPES,
+  ...VIDEO_MIME_TYPES,
+};
+
+const IMAGE_MAX_SIZE = 5 * 1024 * 1024;
+const VIDEO_MAX_SIZE = 512 * 1024 * 1024;
+
+interface ValidatedFile {
+  readonly path: string;
+  readonly mimeType: string;
+  readonly size: number;
+  readonly isVideo: boolean;
+}
+
+async function validateFile(filePath: string): Promise<ValidatedFile> {
+  const sanitizedPath = resolve(filePath);
+  assertSafePath(sanitizedPath);
+
+  let fileStats;
+  try {
+    fileStats = await stat(sanitizedPath);
+  } catch {
+    throw new Error(`File not found: ${basename(sanitizedPath)}`);
+  }
+
+  if (!fileStats.isFile()) {
+    throw new Error(`Path is not a file: ${basename(sanitizedPath)}`);
+  }
+
+  const ext = sanitizedPath.toLowerCase().split('.').pop() ?? '';
+  const mimeType = ALL_MIME_TYPES[ext];
+
+  if (!mimeType) {
+    throw new Error(
+      `Unsupported format. Supported: ${Object.keys(ALL_MIME_TYPES).join(', ')}`
+    );
+  }
+
+  const isVideo = ext in VIDEO_MIME_TYPES;
+  const maxSize = isVideo ? VIDEO_MAX_SIZE : IMAGE_MAX_SIZE;
+
+  if (fileStats.size > maxSize) {
+    const limitMB = maxSize / (1024 * 1024);
+    const fileMB = (fileStats.size / (1024 * 1024)).toFixed(2);
+    throw new Error(`File size ${fileMB}MB exceeds ${limitMB}MB limit`);
+  }
+
+  return { path: sanitizedPath, mimeType, size: fileStats.size, isVideo };
+}
+
+async function readFileChunk(filePath: string, start: number, length: number): Promise<Buffer> {
+  const fh = await open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(length);
+    await fh.read(buffer, 0, length, start);
+    return buffer;
+  } finally {
+    await fh.close();
+  }
+}
+
+async function requireOAuth2Token(): Promise<string> {
+  const token = await getOAuth2Token();
+  if (!token) {
+    throw new Error(
+      'Media upload requires OAuth 2.0 (v1.1 upload was sunset June 2025). ' +
+      'Set TWITTER_OAUTH2_ACCESS_TOKEN or TWITTER_CLIENT_ID + TWITTER_OAUTH2_REFRESH_TOKEN.'
+    );
+  }
+  return token;
+}
+
+async function simpleUpload(file: ValidatedFile, token: string): Promise<string> {
+  const mediaCategory = file.mimeType === 'image/gif' ? 'tweet_gif' : 'tweet_image';
+  const imageBuffer = await readFileChunk(file.path, 0, file.size);
+
+  const formData = new FormData();
+  formData.append('media_data', imageBuffer.toString('base64'));
+  formData.append('media_category', mediaCategory);
+
+  const response = await fetch(UPLOAD_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    console.error(`[Media Upload] API error: ${await response.text()}`);
+    throw new Error(`Upload failed with status ${response.status}`);
+  }
+
+  const data = (await response.json()) as { media_id_string?: string };
+  if (!data.media_id_string) {
+    throw new Error('Upload response missing media_id_string');
+  }
+  return data.media_id_string;
+}
+
+async function chunkedUpload(file: ValidatedFile, token: string): Promise<string> {
+  const headers = { Authorization: `Bearer ${token}` };
+
+  // INIT
+  const initResponse = await fetch(UPLOAD_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      command: 'INIT',
+      total_bytes: file.size.toString(),
+      media_type: file.mimeType,
+      media_category: 'tweet_video',
+    }),
+  });
+
+  if (!initResponse.ok) {
+    console.error(`[Media Upload] INIT error: ${await initResponse.text()}`);
+    throw new Error(`Upload INIT failed with status ${initResponse.status}`);
+  }
+
+  const initData = (await initResponse.json()) as { media_id_string?: string };
+  if (!initData.media_id_string) {
+    throw new Error('Upload INIT response missing media_id_string');
+  }
+  const mediaId = initData.media_id_string;
+
+  // APPEND chunks — read each chunk from disk on demand to avoid loading entire video into memory
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const length = Math.min(CHUNK_SIZE, file.size - start);
+    const chunk = await readFileChunk(file.path, start, length);
+
+    const formData = new FormData();
+    formData.append('command', 'APPEND');
+    formData.append('media_id', mediaId);
+    formData.append('segment_index', i.toString());
+    formData.append('media', new Blob([new Uint8Array(chunk)]));
+
+    const appendResponse = await fetch(UPLOAD_URL, {
+      method: 'POST',
+      headers,
+      body: formData,
+    });
+
+    if (!appendResponse.ok) {
+      console.error(`[Media Upload] APPEND chunk ${i} error: ${await appendResponse.text()}`);
+      throw new Error(`Upload APPEND chunk ${i} failed with status ${appendResponse.status}`);
+    }
+  }
+
+  // FINALIZE
+  const finalizeResponse = await fetch(UPLOAD_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ command: 'FINALIZE', media_id: mediaId }),
+  });
+
+  if (!finalizeResponse.ok) {
+    console.error(`[Media Upload] FINALIZE error: ${await finalizeResponse.text()}`);
+    throw new Error(`Upload FINALIZE failed with status ${finalizeResponse.status}`);
+  }
+
+  const finalizeData = (await finalizeResponse.json()) as {
+    media_id_string: string;
+    processing_info?: { state: string; check_after_secs: number };
+  };
+
+  if (finalizeData.processing_info) {
+    await waitForProcessing(mediaId, token);
+  }
+
+  return mediaId;
+}
+
+const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes max wait
+
+async function waitForProcessing(mediaId: string, token: string): Promise<void> {
+  const deadline = Date.now() + PROCESSING_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const response = await fetch(
+      `${UPLOAD_URL}?command=STATUS&media_id=${mediaId}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!response.ok) {
+      console.error(`[Media Upload] Status check error: ${await response.text()}`);
+      throw new Error(`Media status check failed with status ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      processing_info?: {
+        state: string;
+        check_after_secs: number;
+        error?: { message: string };
+      };
+    };
+
+    if (!data.processing_info) return;
+
+    const { state, check_after_secs, error } = data.processing_info;
+    if (state === 'succeeded') return;
+    if (state === 'failed') {
+      throw new Error(`Video processing failed: ${error?.message ?? 'unknown error'}`);
+    }
+
+    const waitMs = Math.min((check_after_secs ?? 5) * 1000, deadline - Date.now());
+    if (waitMs <= 0) break;
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+
+  throw new Error('Video processing timed out after 5 minutes');
+}
+
+export async function uploadMedia(filePath: string): Promise<string> {
+  if (!hasOAuth2Config()) {
+    throw new Error(
+      'Media upload requires OAuth 2.0 (v1.1 upload endpoint was sunset June 2025). ' +
+      'Set TWITTER_OAUTH2_ACCESS_TOKEN or TWITTER_CLIENT_ID + TWITTER_OAUTH2_REFRESH_TOKEN.'
+    );
+  }
+
+  const file = await validateFile(filePath);
+  const token = await requireOAuth2Token();
+
+  return file.isVideo ? chunkedUpload(file, token) : simpleUpload(file, token);
+}

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,39 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+const rateLimitResets: Record<string, number> = {};
+
+export async function withRateLimit<T>(
+  endpoint: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const now = Date.now();
+  const resetTime = rateLimitResets[endpoint] ?? 0;
+
+  if (now < resetTime) {
+    const waitSeconds = Math.ceil((resetTime - now) / 1000);
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Rate limited on '${endpoint}'. Try again in ${waitSeconds} seconds.`
+    );
+  }
+
+  try {
+    return await fn();
+  } catch (error: unknown) {
+    const err = error as { code?: number; rateLimit?: { reset?: number } };
+
+    if (err?.code === 429) {
+      const resetEpoch = err.rateLimit?.reset;
+      rateLimitResets[endpoint] = resetEpoch
+        ? resetEpoch * 1000
+        : now + 15 * 60 * 1000;
+
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Rate limit exceeded for '${endpoint}'. Please try again later.`
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1,0 +1,276 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const TOOL_DEFINITIONS: Tool[] = [
+  // --- Timeline & Search ---
+  {
+    name: 'get_home_timeline',
+    description: 'Get recent posts from your home timeline',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Number of posts to retrieve (1-100, default 20)',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    },
+  },
+  {
+    name: 'search_tweets',
+    description: 'Search recent posts from the last 7 days. Requires Basic tier or above.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query (supports X search operators like from:, to:, has:, is:)',
+        },
+        limit: {
+          type: 'number',
+          description: 'Number of results (1-100, default 10)',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      required: ['query'],
+    },
+  },
+
+  // --- Tweet CRUD ---
+  {
+    name: 'get_tweet',
+    description: 'Look up a specific post by its ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to look up',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'create_tweet',
+    description: 'Create a new post with optional media attachment. Media upload requires OAuth 2.0 credentials.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: {
+          type: 'string',
+          description: 'The text content of the post (max 280 characters)',
+          maxLength: 280,
+        },
+        image_path: {
+          type: 'string',
+          description: 'Absolute path to an image file (PNG, JPEG, GIF, WEBP, max 5MB)',
+        },
+        video_path: {
+          type: 'string',
+          description: 'Absolute path to a video file (MP4, MOV, AVI, WEBM, M4V, max 512MB). Cannot be used with image_path.',
+        },
+      },
+      required: ['text'],
+    },
+  },
+  {
+    name: 'reply_to_tweet',
+    description: 'Reply to a post with optional media attachment',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to reply to',
+        },
+        text: {
+          type: 'string',
+          description: 'The text content of the reply (max 280 characters)',
+          maxLength: 280,
+        },
+        image_path: {
+          type: 'string',
+          description: 'Absolute path to an image file (PNG, JPEG, GIF, WEBP, max 5MB)',
+        },
+        video_path: {
+          type: 'string',
+          description: 'Absolute path to a video file (MP4, MOV, AVI, WEBM, M4V, max 512MB)',
+        },
+      },
+      required: ['tweet_id', 'text'],
+    },
+  },
+  {
+    name: 'quote_tweet',
+    description: 'Quote a post with your own commentary',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to quote',
+        },
+        text: {
+          type: 'string',
+          description: 'Your commentary text (max 280 characters)',
+          maxLength: 280,
+        },
+      },
+      required: ['tweet_id', 'text'],
+    },
+  },
+  {
+    name: 'delete_tweet',
+    description: 'Delete one of your posts',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to delete',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+
+  // --- Engagement ---
+  {
+    name: 'like_tweet',
+    description: 'Like a post. Not available on Free tier (removed Aug 2025). Requires Basic tier or above.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to like',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'unlike_tweet',
+    description: 'Remove a like from a post',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to unlike',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'retweet',
+    description: 'Repost a post to your timeline',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to repost',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'undo_retweet',
+    description: 'Remove a repost from your timeline',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the reposted post to undo',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'bookmark_tweet',
+    description: 'Bookmark a post for later',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the post to bookmark',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'unbookmark_tweet',
+    description: 'Remove a bookmarked post',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tweet_id: {
+          type: 'string',
+          description: 'The ID of the bookmarked post to remove',
+        },
+      },
+      required: ['tweet_id'],
+    },
+  },
+  {
+    name: 'get_bookmarks',
+    description: 'Get your bookmarked posts',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Number of bookmarks to retrieve (1-100, default 20)',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    },
+  },
+
+  // --- Users ---
+  {
+    name: 'get_user',
+    description: 'Look up a user by their username',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        username: {
+          type: 'string',
+          description: 'The username to look up (without the @ symbol)',
+        },
+      },
+      required: ['username'],
+    },
+  },
+  {
+    name: 'get_user_tweets',
+    description: "Get a user's recent posts by username",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        username: {
+          type: 'string',
+          description: 'The username (without @)',
+        },
+        limit: {
+          type: 'number',
+          description: 'Number of posts to retrieve (1-100, default 10)',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      required: ['username'],
+    },
+  },
+];

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1,0 +1,378 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getClient, getAuthenticatedUserId } from '../client.js';
+import { uploadMedia } from '../media.js';
+import { withRateLimit } from '../rate-limit.js';
+
+type HandlerResult = {
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
+};
+
+function jsonResult(data: unknown): HandlerResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+const TWEET_ID_RE = /^\d{1,20}$/;
+const USERNAME_RE = /^[A-Za-z0-9_]{1,15}$/;
+
+function requireString(args: Record<string, unknown>, field: string): string {
+  const value = args[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Missing or invalid required parameter: '${field}' (expected non-empty string)`
+    );
+  }
+  return value;
+}
+
+function requireTweetId(args: Record<string, unknown>, field: string): string {
+  const value = requireString(args, field);
+  if (!TWEET_ID_RE.test(value)) {
+    throw new McpError(ErrorCode.InvalidRequest, `Invalid tweet ID format for '${field}'`);
+  }
+  return value;
+}
+
+function requireUsername(args: Record<string, unknown>, field: string): string {
+  const value = requireString(args, field);
+  if (!USERNAME_RE.test(value)) {
+    throw new McpError(ErrorCode.InvalidRequest, `Invalid username format for '${field}'`);
+  }
+  return value;
+}
+
+function optionalString(args: Record<string, unknown>, field: string): string | undefined {
+  const value = args[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Invalid parameter: '${field}' (expected string)`
+    );
+  }
+  return value;
+}
+
+function optionalNumber(args: Record<string, unknown>, field: string, fallback: number): number {
+  const value = args[field];
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Invalid parameter: '${field}' (expected number)`
+    );
+  }
+  return value;
+}
+
+async function resolveMediaId(
+  imagePath?: string,
+  videoPath?: string
+): Promise<string | undefined> {
+  if (imagePath && videoPath) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      'Cannot attach both image and video. Provide only one.'
+    );
+  }
+
+  if (!imagePath && !videoPath) return undefined;
+
+  const filePath = (imagePath ?? videoPath)!;
+  try {
+    return await uploadMedia(filePath);
+  } catch (error) {
+    const mediaType = imagePath ? 'image' : 'video';
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Failed to upload ${mediaType}: ${(error as Error).message}`
+    );
+  }
+}
+
+// --- Timeline & Search ---
+
+export async function handleGetHomeTimeline(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const limit = optionalNumber(args, 'limit', 20);
+  const client = await getClient();
+
+  const timeline = await withRateLimit('home_timeline', () =>
+    client.v2.homeTimeline({
+      max_results: Math.max(1, Math.min(limit, 100)),
+      'tweet.fields': ['author_id', 'created_at', 'public_metrics', 'referenced_tweets'],
+      expansions: ['author_id', 'referenced_tweets.id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+
+  return jsonResult(timeline.data);
+}
+
+export async function handleSearchTweets(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const query = requireString(args, 'query');
+  const limit = optionalNumber(args, 'limit', 10);
+  const client = await getClient();
+
+  const results = await withRateLimit('search', () =>
+    client.v2.search(query, {
+      max_results: Math.max(1, Math.min(limit, 100)),
+      'tweet.fields': ['author_id', 'created_at', 'public_metrics'],
+      expansions: ['author_id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+
+  return jsonResult(results.data);
+}
+
+// --- Tweet CRUD ---
+
+export async function handleGetTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+
+  const tweet = await withRateLimit('get_tweet', () =>
+    client.v2.singleTweet(tweetId, {
+      'tweet.fields': [
+        'author_id',
+        'created_at',
+        'public_metrics',
+        'referenced_tweets',
+        'conversation_id',
+      ],
+      expansions: ['author_id', 'referenced_tweets.id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+
+  return jsonResult(tweet.data);
+}
+
+export async function handleCreateTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const text = requireString(args, 'text');
+  const imagePath = optionalString(args, 'image_path');
+  const videoPath = optionalString(args, 'video_path');
+  const client = await getClient();
+
+  const mediaId = await resolveMediaId(imagePath, videoPath);
+
+  const tweet = await withRateLimit('create_tweet', () =>
+    mediaId
+      ? client.v2.tweet({ text, media: { media_ids: [mediaId] } })
+      : client.v2.tweet(text)
+  );
+
+  return jsonResult(tweet.data);
+}
+
+export async function handleReplyToTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const text = requireString(args, 'text');
+  const imagePath = optionalString(args, 'image_path');
+  const videoPath = optionalString(args, 'video_path');
+  const client = await getClient();
+
+  const mediaId = await resolveMediaId(imagePath, videoPath);
+
+  const reply = await withRateLimit('reply', () =>
+    mediaId
+      ? client.v2.tweet({
+          text,
+          reply: { in_reply_to_tweet_id: tweetId },
+          media: { media_ids: [mediaId] },
+        })
+      : client.v2.reply(text, tweetId)
+  );
+
+  return jsonResult(reply.data);
+}
+
+export async function handleQuoteTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const text = requireString(args, 'text');
+  const client = await getClient();
+
+  const tweet = await withRateLimit('quote', () =>
+    client.v2.tweet({ text, quote_tweet_id: tweetId })
+  );
+
+  return jsonResult(tweet.data);
+}
+
+export async function handleDeleteTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+
+  const deleted = await withRateLimit('delete_tweet', () =>
+    client.v2.deleteTweet(tweetId)
+  );
+
+  return jsonResult(deleted.data);
+}
+
+// --- Engagement ---
+
+export async function handleLikeTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+  const userId = await getAuthenticatedUserId();
+
+  const result = await withRateLimit('like', () =>
+    client.v2.like(userId, tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleUnlikeTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+  const userId = await getAuthenticatedUserId();
+
+  const result = await withRateLimit('unlike', () =>
+    client.v2.unlike(userId, tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleRetweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+  const userId = await getAuthenticatedUserId();
+
+  const result = await withRateLimit('retweet', () =>
+    client.v2.retweet(userId, tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleUndoRetweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+  const userId = await getAuthenticatedUserId();
+
+  const result = await withRateLimit('unretweet', () =>
+    client.v2.unretweet(userId, tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleBookmarkTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+
+  const result = await withRateLimit('bookmark', () =>
+    client.v2.bookmark(tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleUnbookmarkTweet(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const tweetId = requireTweetId(args, 'tweet_id');
+  const client = await getClient();
+
+  const result = await withRateLimit('unbookmark', () =>
+    client.v2.deleteBookmark(tweetId)
+  );
+
+  return jsonResult(result.data);
+}
+
+export async function handleGetBookmarks(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const limit = optionalNumber(args, 'limit', 20);
+  const client = await getClient();
+
+  const bookmarks = await withRateLimit('get_bookmarks', () =>
+    client.v2.bookmarks({
+      max_results: Math.max(1, Math.min(limit, 100)),
+      'tweet.fields': ['author_id', 'created_at', 'public_metrics'],
+      expansions: ['author_id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+
+  return jsonResult(bookmarks.data);
+}
+
+// --- Users ---
+
+export async function handleGetUser(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const username = requireUsername(args, 'username');
+  const client = await getClient();
+
+  const user = await withRateLimit('get_user', () =>
+    client.v2.userByUsername(username, {
+      'user.fields': [
+        'description',
+        'public_metrics',
+        'created_at',
+        'location',
+        'url',
+        'verified',
+      ],
+    })
+  );
+
+  return jsonResult(user.data);
+}
+
+export async function handleGetUserTweets(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const username = requireUsername(args, 'username');
+  const limit = optionalNumber(args, 'limit', 10);
+  const client = await getClient();
+
+  const user = await withRateLimit('get_user', () =>
+    client.v2.userByUsername(username)
+  );
+
+  if (!user.data) {
+    throw new McpError(ErrorCode.InvalidRequest, `User @${username} not found`);
+  }
+
+  const tweets = await withRateLimit('user_tweets', () =>
+    client.v2.userTimeline(user.data.id, {
+      max_results: Math.max(1, Math.min(limit, 100)),
+      'tweet.fields': ['created_at', 'public_metrics', 'referenced_tweets'],
+    })
+  );
+
+  return jsonResult(tweets.data);
+}


### PR DESCRIPTION
## Summary

- **v2 API migration**: Replaced dead v1.1 media upload (`client.v1.uploadMedia()`, sunset June 2025) with v2 upload endpoint using native `fetch` with chunked streaming for videos
- **OAuth 2.0 support**: Added dual auth — OAuth 1.0a for tweet operations, OAuth 2.0 (required) for media upload, with auto-refresh and token persistence
- **12 new tools**: `search_tweets`, `get_tweet`, `quote_tweet`, `like_tweet`, `unlike_tweet`, `retweet`, `undo_retweet`, `bookmark_tweet`, `unbookmark_tweet`, `get_bookmarks`, `get_user`, `get_user_tweets`
- **Security hardening**: Path traversal protection (allow-list), input format validation (tweet IDs, usernames), error sanitization, token refresh mutex, Windows token file warning
- **Architecture**: Split 451-line monolith into 6 focused modules (all <400 lines)
- **Version bump**: 1.0.0 → 2.0.0, Node.js minimum raised to 18+

## Test plan

- [ ] Verify OAuth 1.0a auth still works for tweet CRUD operations
- [ ] Verify OAuth 2.0 token refresh flow with `TWITTER_CLIENT_ID` + `TWITTER_OAUTH2_REFRESH_TOKEN`
- [ ] Test media upload (image + video) with OAuth 2.0 credentials
- [ ] Test path traversal rejection (file outside home/tmp directory)
- [ ] Test input validation rejects malformed tweet IDs and usernames
- [ ] Verify new tools: search, get_tweet, quote, like/unlike, retweet/undo, bookmarks, user lookup
- [ ] Verify rate limit errors surface correctly to MCP client
- [ ] Test on Windows and Unix for token file behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)