### PR TITLE
Add user data endpoint tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # X MCP Server
 
-A Model Context Protocol (MCP) server for X (Twitter) integration. Provides 16 tools for reading timelines, posting, searching, engagement (likes, retweets, bookmarks), and user lookup. Designed for use with Claude desktop and other MCP-compatible clients.
+A Model Context Protocol (MCP) server for X (Twitter) integration. Provides 26 tools for reading timelines, posting, searching, engagement (likes, retweets, bookmarks), user lookup, follower export, mentions, likes, articles, and lists. Designed for use with Claude desktop and other MCP-compatible clients.
 
 <a href="https://glama.ai/mcp/servers/5nx3qqiunw"><img width="380" height="200" src="https://glama.ai/mcp/servers/5nx3qqiunw/badge" alt="X Server MCP server" /></a>
 
 ## Features
 
-- **Timeline & Search** — Home timeline, search recent posts (7-day window)
-- **Post Management** — Create, reply, quote, delete posts with optional media
-- **Engagement** — Like/unlike, retweet/undo, bookmark/unbookmark
-- **User Lookup** — Get user profiles and their recent posts
-- **Media Upload** — Images (PNG, JPEG, GIF, WEBP) and videos (MP4, MOV, AVI, WEBM, M4V) via v2 upload API
-- **Dual Auth** — OAuth 1.0a for post operations, OAuth 2.0 for media upload (v1.1 upload was sunset June 2025)
-- **Rate Limiting** — Automatic per-endpoint rate limit tracking with clear error messages
-- **TypeScript** — Full type safety, modular file structure
+- **Timeline & Search** - Home timeline, search recent posts (7-day window)
+- **Post Management** - Create, reply, quote, delete posts with optional media
+- **Engagement** - Like/unlike, retweet/undo, bookmark/unbookmark
+- **User Data** - Mentions, liked posts, followers, following, blocks, mutes, owned lists, followed lists, and list memberships
+- **User Lookup** - Get user profiles and their recent posts
+- **Media Upload** - Images (PNG, JPEG, GIF, WEBP) and videos (MP4, MOV, AVI, WEBM, M4V) via v2 upload API
+- **Dual Auth** - OAuth 1.0a for post operations, OAuth 2.0 for media upload (v1.1 upload was sunset June 2025)
+- **Rate Limiting** - Automatic per-endpoint rate limit tracking with clear error messages
+- **TypeScript** - Full type safety, modular file structure
 
 ## Prerequisites
 
@@ -67,13 +68,13 @@ Works for all post/engagement/search/user operations.
 
 The v1.1 media upload endpoint was sunset in June 2025. Media upload now requires OAuth 2.0 via the v2 upload API.
 
-**Option A — Direct access token:**
+**Option A - Direct access token:**
 
 | Variable | Description |
 |----------|-------------|
 | `TWITTER_OAUTH2_ACCESS_TOKEN` | OAuth 2.0 user access token (expires in 2 hours) |
 
-**Option B — Auto-refresh (recommended for long-running servers):**
+**Option B - Auto-refresh (recommended for long-running servers):**
 
 | Variable | Description |
 |----------|-------------|
@@ -87,7 +88,7 @@ Tokens are auto-refreshed and persisted to `~/.x-mcp-tokens.json`.
 1. In your app settings, enable OAuth 2.0
 2. Set type to "Confidential client" or "Public client"
 3. Add a callback URL
-4. Request scopes: `tweet.read`, `tweet.write`, `users.read`, `media.write`, `offline.access`, `like.read`, `like.write`, `bookmark.read`, `bookmark.write`
+4. Request scopes: `tweet.read`, `tweet.write`, `users.read`, `media.write`, `offline.access`, `like.read`, `like.write`, `bookmark.read`, `bookmark.write`, `follows.read`, `block.read`, `mute.read`, `list.read`
 
 ## Claude Desktop Configuration
 
@@ -111,7 +112,7 @@ Add to `%APPDATA%/Claude/claude_desktop_config.json`:
 }
 ```
 
-## Available Tools (16)
+## Available Tools (26)
 
 ### Timeline & Search
 
@@ -148,6 +149,21 @@ Add to `%APPDATA%/Claude/claude_desktop_config.json`:
 |------|-------------|---------------|
 | `get_user` | Look up user by username | `username` |
 | `get_user_tweets` | Get a user's recent posts | `username`, `limit` |
+| `get_user_mentions` | Get posts mentioning a user | `username`, `limit` |
+| `get_user_liked_tweets` | Get a user's liked posts | `username`, `limit` |
+| `get_user_followers` | Get a user's followers | `username`, `limit` |
+| `get_user_following` | Get accounts a user follows | `username`, `limit` |
+| `get_blocking_users` | Get users blocked by the authenticated account | `limit` |
+| `get_muting_users` | Get users muted by the authenticated account | `limit` |
+| `get_owned_lists` | Get lists owned by a user | `username`, `limit` |
+| `get_followed_lists` | Get lists followed by a user | `username`, `limit` |
+| `get_list_memberships` | Get lists a user belongs to | `username`, `limit` |
+
+### Articles
+
+| Tool | Description | Key Parameters |
+|------|-------------|---------------|
+| `get_article` | Fetch the full body content of an X Article post | `tweet_id` |
 
 ## Media Support
 
@@ -161,7 +177,7 @@ Add to `%APPDATA%/Claude/claude_desktop_config.json`:
 
 - **Input validation:** Tweet IDs must be numeric (1-20 digits), usernames must match `[A-Za-z0-9_]{1,15}`
 - **Media path restriction:** Upload paths are validated against an allow-list (home directory, temp directory)
-- **Token storage:** OAuth 2.0 tokens persisted to `~/.x-mcp-tokens.json` with `0o600` permissions (Unix). On Windows, file permissions are not enforced by the OS — protect the file via NTFS ACLs or use environment variables instead.
+- **Token storage:** OAuth 2.0 tokens persisted to `~/.x-mcp-tokens.json` with `0o600` permissions (Unix). On Windows, file permissions are not enforced by the OS - protect the file via NTFS ACLs or use environment variables instead.
 - **Error sanitization:** X API error details are logged server-side only; sanitized messages are returned to MCP clients
 - **Refresh mutex:** Concurrent token refresh attempts are deduplicated to prevent race conditions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,21 @@ import {
   handleBookmarkTweet,
   handleUnbookmarkTweet,
   handleGetBookmarks,
-  handleGetUser,
-  handleGetUserTweets,
   handleGetArticle,
 } from './tools/handlers.js';
+import {
+  handleGetUser,
+  handleGetUserTweets,
+  handleGetUserMentions,
+  handleGetUserLikedTweets,
+  handleGetUserFollowers,
+  handleGetUserFollowing,
+  handleGetBlockingUsers,
+  handleGetMutingUsers,
+  handleGetOwnedLists,
+  handleGetFollowedLists,
+  handleGetListMemberships,
+} from './tools/user-data-handlers.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
   readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
@@ -49,6 +60,15 @@ const HANDLERS: Readonly<Record<string, ToolHandler>> = {
   get_bookmarks: handleGetBookmarks,
   get_user: handleGetUser,
   get_user_tweets: handleGetUserTweets,
+  get_user_mentions: handleGetUserMentions,
+  get_user_liked_tweets: handleGetUserLikedTweets,
+  get_user_followers: handleGetUserFollowers,
+  get_user_following: handleGetUserFollowing,
+  get_blocking_users: handleGetBlockingUsers,
+  get_muting_users: handleGetMutingUsers,
+  get_owned_lists: handleGetOwnedLists,
+  get_followed_lists: handleGetFollowedLists,
+  get_list_memberships: handleGetListMemberships,
   get_article: handleGetArticle,
 };
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1,4 +1,5 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { USER_DATA_TOOL_DEFINITIONS } from './user-data-definitions.js';
 
 export const TOOL_DEFINITIONS: Tool[] = [
   // --- Timeline & Search ---
@@ -273,6 +274,7 @@ export const TOOL_DEFINITIONS: Tool[] = [
       required: ['username'],
     },
   },
+  ...USER_DATA_TOOL_DEFINITIONS,
   {
     name: 'get_article',
     description: 'Fetch the full body content of an X Article post by its tweet ID',

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1,4 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { TweetV2 } from 'twitter-api-v2';
 import { getClient, getAuthenticatedUserId } from '../client.js';
 import { uploadMedia } from '../media.js';
 import { withRateLimit } from '../rate-limit.js';
@@ -14,7 +15,11 @@ function jsonResult(data: unknown): HandlerResult {
 }
 
 const TWEET_ID_RE = /^\d{1,20}$/;
-const USERNAME_RE = /^[A-Za-z0-9_]{1,15}$/;
+const DEFAULT_TWEET_FIELDS: Array<keyof TweetV2> = [
+  'author_id',
+  'created_at',
+  'public_metrics',
+];
 
 function requireString(args: Record<string, unknown>, field: string): string {
   const value = args[field];
@@ -31,14 +36,6 @@ function requireTweetId(args: Record<string, unknown>, field: string): string {
   const value = requireString(args, field);
   if (!TWEET_ID_RE.test(value)) {
     throw new McpError(ErrorCode.InvalidRequest, `Invalid tweet ID format for '${field}'`);
-  }
-  return value;
-}
-
-function requireUsername(args: Record<string, unknown>, field: string): string {
-  const value = requireString(args, field);
-  if (!USERNAME_RE.test(value)) {
-    throw new McpError(ErrorCode.InvalidRequest, `Invalid username format for '${field}'`);
   }
   return value;
 }
@@ -65,6 +62,11 @@ function optionalNumber(args: Record<string, unknown>, field: string, fallback: 
     );
   }
   return value;
+}
+
+function normalizedLimit(args: Record<string, unknown>, fallback: number): number {
+  const limit = optionalNumber(args, 'limit', fallback);
+  return Math.max(1, Math.min(limit, 100));
 }
 
 async function resolveMediaId(
@@ -97,12 +99,12 @@ async function resolveMediaId(
 export async function handleGetHomeTimeline(
   args: Record<string, unknown>
 ): Promise<HandlerResult> {
-  const limit = optionalNumber(args, 'limit', 20);
+  const limit = normalizedLimit(args, 20);
   const client = await getClient();
 
   const timeline = await withRateLimit('home_timeline', () =>
     client.v2.homeTimeline({
-      max_results: Math.max(1, Math.min(limit, 100)),
+      max_results: limit,
       'tweet.fields': ['author_id', 'created_at', 'public_metrics', 'referenced_tweets'],
       expansions: ['author_id', 'referenced_tweets.id'],
       'user.fields': ['name', 'username'],
@@ -116,13 +118,13 @@ export async function handleSearchTweets(
   args: Record<string, unknown>
 ): Promise<HandlerResult> {
   const query = requireString(args, 'query');
-  const limit = optionalNumber(args, 'limit', 10);
+  const limit = normalizedLimit(args, 10);
   const client = await getClient();
 
   const results = await withRateLimit('search', () =>
     client.v2.search(query, {
-      max_results: Math.max(1, Math.min(limit, 100)),
-      'tweet.fields': ['author_id', 'created_at', 'public_metrics'],
+      max_results: limit,
+      'tweet.fields': DEFAULT_TWEET_FIELDS,
       expansions: ['author_id'],
       'user.fields': ['name', 'username'],
     })
@@ -313,68 +315,19 @@ export async function handleUnbookmarkTweet(
 export async function handleGetBookmarks(
   args: Record<string, unknown>
 ): Promise<HandlerResult> {
-  const limit = optionalNumber(args, 'limit', 20);
+  const limit = normalizedLimit(args, 20);
   const client = await getClient();
 
   const bookmarks = await withRateLimit('get_bookmarks', () =>
     client.v2.bookmarks({
-      max_results: Math.max(1, Math.min(limit, 100)),
-      'tweet.fields': ['author_id', 'created_at', 'public_metrics'],
+      max_results: limit,
+      'tweet.fields': DEFAULT_TWEET_FIELDS,
       expansions: ['author_id'],
       'user.fields': ['name', 'username'],
     })
   );
 
   return jsonResult(bookmarks.data);
-}
-
-// --- Users ---
-
-export async function handleGetUser(
-  args: Record<string, unknown>
-): Promise<HandlerResult> {
-  const username = requireUsername(args, 'username');
-  const client = await getClient();
-
-  const user = await withRateLimit('get_user', () =>
-    client.v2.userByUsername(username, {
-      'user.fields': [
-        'description',
-        'public_metrics',
-        'created_at',
-        'location',
-        'url',
-        'verified',
-      ],
-    })
-  );
-
-  return jsonResult(user.data);
-}
-
-export async function handleGetUserTweets(
-  args: Record<string, unknown>
-): Promise<HandlerResult> {
-  const username = requireUsername(args, 'username');
-  const limit = optionalNumber(args, 'limit', 10);
-  const client = await getClient();
-
-  const user = await withRateLimit('get_user', () =>
-    client.v2.userByUsername(username)
-  );
-
-  if (!user.data) {
-    throw new McpError(ErrorCode.InvalidRequest, `User @${username} not found`);
-  }
-
-  const tweets = await withRateLimit('user_tweets', () =>
-    client.v2.userTimeline(user.data.id, {
-      max_results: Math.max(1, Math.min(limit, 100)),
-      'tweet.fields': ['created_at', 'public_metrics', 'referenced_tweets'],
-    })
-  );
-
-  return jsonResult(tweets.data);
 }
 
 // --- Articles ---
@@ -394,5 +347,3 @@ export async function handleGetArticle(
 
   return jsonResult(result.data);
 }
-
-

--- a/src/tools/user-data-definitions.ts
+++ b/src/tools/user-data-definitions.ts
@@ -1,0 +1,106 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+function usernameLimitTool(
+  name: string,
+  description: string,
+  limitDescription: string,
+  defaultLimit: number
+): Tool {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        username: {
+          type: 'string',
+          description: 'The username (without @)',
+        },
+        limit: {
+          type: 'number',
+          description: `${limitDescription} (1-100, default ${defaultLimit})`,
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      required: ['username'],
+    },
+  };
+}
+
+function limitOnlyTool(
+  name: string,
+  description: string,
+  limitDescription: string
+): Tool {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: `${limitDescription} (1-100, default 20)`,
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    },
+  };
+}
+
+export const USER_DATA_TOOL_DEFINITIONS: Tool[] = [
+  usernameLimitTool(
+    'get_user_mentions',
+    'Get recent posts mentioning a user by username',
+    'Number of mentions to retrieve',
+    10
+  ),
+  usernameLimitTool(
+    'get_user_liked_tweets',
+    "Get a user's recently liked posts by username",
+    'Number of liked posts to retrieve',
+    10
+  ),
+  usernameLimitTool(
+    'get_user_followers',
+    "Get a user's followers by username",
+    'Number of followers to retrieve',
+    20
+  ),
+  usernameLimitTool(
+    'get_user_following',
+    'Get accounts a user follows by username',
+    'Number of followed accounts to retrieve',
+    20
+  ),
+  limitOnlyTool(
+    'get_blocking_users',
+    'Get users blocked by the authenticated account',
+    'Number of blocked users to retrieve'
+  ),
+  limitOnlyTool(
+    'get_muting_users',
+    'Get users muted by the authenticated account',
+    'Number of muted users to retrieve'
+  ),
+  usernameLimitTool(
+    'get_owned_lists',
+    'Get lists owned by a user by username',
+    'Number of lists to retrieve',
+    20
+  ),
+  usernameLimitTool(
+    'get_followed_lists',
+    'Get lists followed by a user by username',
+    'Number of lists to retrieve',
+    20
+  ),
+  usernameLimitTool(
+    'get_list_memberships',
+    'Get lists a user belongs to by username',
+    'Number of lists to retrieve',
+    20
+  ),
+];

--- a/src/tools/user-data-handlers.ts
+++ b/src/tools/user-data-handlers.ts
@@ -1,0 +1,240 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { TListV2Field, TweetV2, UserV2 } from 'twitter-api-v2';
+import { getAuthenticatedUserId, getClient } from '../client.js';
+import { withRateLimit } from '../rate-limit.js';
+
+type HandlerResult = {
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
+};
+
+type Client = Awaited<ReturnType<typeof getClient>>;
+type DataResult = { readonly data: unknown };
+type UserScopedLoader = (
+  client: Client,
+  userId: string,
+  limit: number
+) => Promise<DataResult>;
+
+const USERNAME_RE = /^[A-Za-z0-9_]{1,15}$/;
+const DEFAULT_TWEET_FIELDS: Array<keyof TweetV2> = [
+  'author_id',
+  'created_at',
+  'public_metrics',
+];
+const DEFAULT_USER_FIELDS: Array<keyof UserV2> = [
+  'description',
+  'public_metrics',
+  'created_at',
+  'location',
+  'url',
+  'verified',
+];
+const DEFAULT_LIST_FIELDS: TListV2Field[] = [
+  'created_at',
+  'description',
+  'follower_count',
+  'member_count',
+];
+
+function jsonResult(data: unknown): HandlerResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function requireUsername(args: Record<string, unknown>): string {
+  const value = args.username;
+  if (typeof value !== 'string' || !USERNAME_RE.test(value)) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      "Missing or invalid required parameter: 'username'"
+    );
+  }
+  return value;
+}
+
+function optionalNumber(args: Record<string, unknown>, fallback: number): number {
+  const value = args.limit;
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      "Invalid parameter: 'limit' (expected number)"
+    );
+  }
+  return value;
+}
+
+function normalizedLimit(args: Record<string, unknown>, fallback: number): number {
+  const limit = optionalNumber(args, fallback);
+  return Math.max(1, Math.min(limit, 100));
+}
+
+async function resolveUserIdByUsername(client: Client, username: string): Promise<string> {
+  const user = await withRateLimit('get_user', () =>
+    client.v2.userByUsername(username)
+  );
+
+  if (!user.data) {
+    throw new McpError(ErrorCode.InvalidRequest, `User @${username} not found`);
+  }
+
+  return user.data.id;
+}
+
+async function loadUserScopedResult(
+  args: Record<string, unknown>,
+  rateLimitKey: string,
+  defaultLimit: number,
+  loader: UserScopedLoader
+): Promise<HandlerResult> {
+  const username = requireUsername(args);
+  const limit = normalizedLimit(args, defaultLimit);
+  const client = await getClient();
+  const userId = await resolveUserIdByUsername(client, username);
+  const result = await withRateLimit(rateLimitKey, () => loader(client, userId, limit));
+
+  return jsonResult(result.data);
+}
+
+async function loadAuthenticatedResult(
+  args: Record<string, unknown>,
+  rateLimitKey: string,
+  loader: UserScopedLoader
+): Promise<HandlerResult> {
+  const limit = normalizedLimit(args, 20);
+  const client = await getClient();
+  const userId = await getAuthenticatedUserId();
+  const result = await withRateLimit(rateLimitKey, () => loader(client, userId, limit));
+
+  return jsonResult(result.data);
+}
+
+export async function handleGetUser(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  const username = requireUsername(args);
+  const client = await getClient();
+
+  const user = await withRateLimit('get_user', () =>
+    client.v2.userByUsername(username, {
+      'user.fields': DEFAULT_USER_FIELDS,
+    })
+  );
+
+  return jsonResult(user.data);
+}
+
+export async function handleGetUserTweets(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'user_tweets', 10, (client, userId, limit) =>
+    client.v2.userTimeline(userId, {
+      max_results: limit,
+      'tweet.fields': ['created_at', 'public_metrics', 'referenced_tweets'],
+    })
+  );
+}
+
+export async function handleGetUserMentions(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'user_mentions', 10, (client, userId, limit) =>
+    client.v2.userMentionTimeline(userId, {
+      max_results: limit,
+      'tweet.fields': DEFAULT_TWEET_FIELDS,
+      expansions: ['author_id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+}
+
+export async function handleGetUserLikedTweets(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'user_liked_tweets', 10, (client, userId, limit) =>
+    client.v2.userLikedTweets(userId, {
+      max_results: limit,
+      'tweet.fields': DEFAULT_TWEET_FIELDS,
+      expansions: ['author_id'],
+      'user.fields': ['name', 'username'],
+    })
+  );
+}
+
+export async function handleGetUserFollowers(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'user_followers', 20, (client, userId, limit) =>
+    client.v2.followers(userId, {
+      max_results: limit,
+      'user.fields': DEFAULT_USER_FIELDS,
+    })
+  );
+}
+
+export async function handleGetUserFollowing(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'user_following', 20, (client, userId, limit) =>
+    client.v2.following(userId, {
+      max_results: limit,
+      'user.fields': DEFAULT_USER_FIELDS,
+    })
+  );
+}
+
+export async function handleGetBlockingUsers(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadAuthenticatedResult(args, 'blocking_users', (client, userId, limit) =>
+    client.v2.userBlockingUsers(userId, {
+      max_results: limit,
+      'user.fields': DEFAULT_USER_FIELDS,
+    })
+  );
+}
+
+export async function handleGetMutingUsers(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadAuthenticatedResult(args, 'muting_users', (client, userId, limit) =>
+    client.v2.userMutingUsers(userId, {
+      max_results: limit,
+      'user.fields': DEFAULT_USER_FIELDS,
+    })
+  );
+}
+
+export async function handleGetOwnedLists(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'owned_lists', 20, (client, userId, limit) =>
+    client.v2.listsOwned(userId, {
+      max_results: limit,
+      'list.fields': DEFAULT_LIST_FIELDS,
+    })
+  );
+}
+
+export async function handleGetFollowedLists(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'followed_lists', 20, (client, userId, limit) =>
+    client.v2.listFollowed(userId, {
+      max_results: limit,
+      'list.fields': DEFAULT_LIST_FIELDS,
+    })
+  );
+}
+
+export async function handleGetListMemberships(
+  args: Record<string, unknown>
+): Promise<HandlerResult> {
+  return loadUserScopedResult(args, 'list_memberships', 20, (client, userId, limit) =>
+    client.v2.listMemberships(userId, {
+      max_results: limit,
+      'list.fields': DEFAULT_LIST_FIELDS,
+    })
+  );
+}


### PR DESCRIPTION
## Summary

- Add read-only MCP tools for mentions, liked posts, followers, following, blocks, mutes, owned lists, followed lists, and list memberships.
- Keep user-facing inputs consistent with the existing `get_user` and `get_user_tweets` tools by accepting usernames plus a clamped `limit`.
- Document the actual 26-tool count, OAuth scopes, the new user-data tools, and the existing `get_article` tool.

## Notes

This addresses most of the user-data endpoint request in #8. `get_bookmarks` and `get_user_tweets` already covered two of the requested endpoints before this patch.

I did not add pinned-list reads because the current `twitter-api-v2` version exposes pin and unpin writes, but not a typed read helper for `GET /2/users/{id}/pinned_lists`.

## Validation

- `npm run build`
- 26-tool definition count smoke test against `build/tools/definitions.js`
- `npx --yes markdown-link-check README.md`
- temporary lockfile audit: `npm install --package-lock-only --ignore-scripts` then `npm audit --omit=dev`, with the generated lockfile removed before commit
- `git diff --cached --check`
- staged added-line public-hygiene scan
