### PR TITLE
Add optional Xquik search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ Add to `%APPDATA%/Claude/claude_desktop_config.json`:
 }
 ```
 
+### Optional Xquik Search Backend
+
+`search_tweets` can use Xquik while the rest of the server keeps the default
+X API client. Set:
+
+| Variable | Description |
+|----------|-------------|
+| `X_MCP_SEARCH_BACKEND=xquik` | Routes only `search_tweets` to Xquik |
+| `XQUIK_API_KEY` | Xquik API key |
+| `XQUIK_API_BASE_URL` | Optional base URL, defaults to `https://xquik.com/api/v1` |
+
 ## Available Tools (26)
 
 ### Timeline & Search

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -3,6 +3,7 @@ import type { TweetV2 } from 'twitter-api-v2';
 import { getClient, getAuthenticatedUserId } from '../client.js';
 import { uploadMedia } from '../media.js';
 import { withRateLimit } from '../rate-limit.js';
+import { searchTweetsWithXquik, useXquikSearchBackend } from '../xquik.js';
 
 type HandlerResult = {
   readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
@@ -119,6 +120,11 @@ export async function handleSearchTweets(
 ): Promise<HandlerResult> {
   const query = requireString(args, 'query');
   const limit = normalizedLimit(args, 10);
+
+  if (useXquikSearchBackend()) {
+    return jsonResult(await searchTweetsWithXquik(query, limit));
+  }
+
   const client = await getClient();
 
   const results = await withRateLimit('search', () =>

--- a/src/xquik.ts
+++ b/src/xquik.ts
@@ -1,0 +1,135 @@
+const DEFAULT_XQUIK_BASE_URL = 'https://xquik.com/api/v1';
+const XQUIK_BACKEND_NAME = 'xquik';
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+interface XquikSearchResponse extends JsonObject {
+  readonly tweets?: unknown;
+  readonly data?: unknown;
+  readonly results?: unknown;
+}
+
+interface XquikMappedTweet extends JsonObject {
+  readonly id?: string;
+  readonly text?: string;
+  readonly author_id?: string;
+  readonly created_at?: string;
+  readonly public_metrics?: JsonObject;
+  readonly author?: unknown;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(source: JsonObject, key: string): string | undefined {
+  const value = source[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readNumber(source: JsonObject, key: string): number | undefined {
+  const value = source[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function compactObject(source: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(source).filter(([, value]) => value !== undefined)
+  );
+}
+
+function readXquikTweets(body: XquikSearchResponse): readonly unknown[] {
+  const tweets = body.tweets ?? body.data ?? body.results;
+  return Array.isArray(tweets) ? tweets : [];
+}
+
+function mapPublicMetrics(tweet: JsonObject): JsonObject | undefined {
+  const metrics = compactObject({
+    retweet_count:
+      readNumber(tweet, 'retweetCount') ?? readNumber(tweet, 'retweet_count'),
+    reply_count: readNumber(tweet, 'replyCount') ?? readNumber(tweet, 'reply_count'),
+    like_count: readNumber(tweet, 'likeCount') ?? readNumber(tweet, 'like_count'),
+    quote_count: readNumber(tweet, 'quoteCount') ?? readNumber(tweet, 'quote_count'),
+    bookmark_count:
+      readNumber(tweet, 'bookmarkCount') ?? readNumber(tweet, 'bookmark_count'),
+    impression_count:
+      readNumber(tweet, 'viewCount') ?? readNumber(tweet, 'impression_count'),
+  });
+  return Object.keys(metrics).length > 0 ? metrics : undefined;
+}
+
+function mapXquikTweet(tweet: unknown): XquikMappedTweet {
+  if (!isObject(tweet)) return {};
+  const author = isObject(tweet.author) ? tweet.author : undefined;
+  return compactObject({
+    id: readString(tweet, 'id'),
+    text: readString(tweet, 'text'),
+    author_id:
+      readString(tweet, 'author_id') ??
+      (author ? readString(author, 'id') : undefined),
+    created_at: readString(tweet, 'created_at') ?? readString(tweet, 'createdAt'),
+    public_metrics: mapPublicMetrics(tweet),
+    author,
+  });
+}
+
+function getXquikApiKey(): string {
+  const apiKey = process.env.XQUIK_API_KEY;
+  if (!apiKey) {
+    throw new Error('XQUIK_API_KEY is required when X_MCP_SEARCH_BACKEND=xquik');
+  }
+  return apiKey;
+}
+
+function getXquikBaseUrl(): string {
+  return (process.env.XQUIK_API_BASE_URL ?? DEFAULT_XQUIK_BASE_URL).replace(
+    /\/+$/,
+    ''
+  );
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as unknown;
+    if (isObject(body)) {
+      return (
+        readString(body, 'message') ??
+        readString(body, 'error') ??
+        response.statusText
+      );
+    }
+  } catch {
+    return response.statusText;
+  }
+  return response.statusText;
+}
+
+export function useXquikSearchBackend(): boolean {
+  return process.env.X_MCP_SEARCH_BACKEND === XQUIK_BACKEND_NAME;
+}
+
+export async function searchTweetsWithXquik(
+  query: string,
+  limit: number
+): Promise<readonly XquikMappedTweet[]> {
+  const url = new URL(`${getXquikBaseUrl()}/x/tweets/search`);
+  url.searchParams.set('q', query);
+  url.searchParams.set('limit', String(limit));
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': getXquikApiKey(),
+    },
+  });
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response);
+    throw new Error(
+      `Xquik search failed with HTTP ${response.status}: ${message}`
+    );
+  }
+
+  const body = (await response.json()) as XquikSearchResponse;
+  return readXquikTweets(body).map(mapXquikTweet);
+}


### PR DESCRIPTION
## Summary
- Add optional Xquik routing for `search_tweets` behind `X_MCP_SEARCH_BACKEND=xquik`.
- Keep the existing X API client as the default for every tool.
- Document `XQUIK_API_KEY` and the optional Xquik base URL.

## Validation
- `npm run build`
- Mocked `searchTweetsWithXquik` fetch mapping check
